### PR TITLE
Fixed GiiKER v3 Supercube being filtered out.

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ class Giiker extends EventEmitter {
 
     const device = await window.navigator.bluetooth.requestDevice({
       filters: [{
-        namePrefix: 'GiC',
+        namePrefix: 'Gi',
       }],
       optionalServices: [SERVICE_UUID, SYSTEM_SERVICE_UUID],
     });


### PR DESCRIPTION
The v3 GiiKER Supercube is 'GiS' rather than 'GiC' and was being filtered out.